### PR TITLE
Ajout restrictions de merge de branche

### DIFF
--- a/.github/workflows/restrict-merge-source.yml
+++ b/.github/workflows/restrict-merge-source.yml
@@ -1,4 +1,4 @@
-name: Restrict merge source
+name: Restriction merge de branche
 
 on:
   pull_request:


### PR DESCRIPTION
Ici j'ai crée un workflow github qui sert à empêcher de créer une pull request depuis une autre branche que [development](https://github.com/Aonfu/WE4A/tree/development) vers [master](https://github.com/Aonfu/WE4A/tree/master). 
Cela protège donc notre branche principale (en entreprise c'est la branche stable qui est en production) des sources extérieurs à la branche de dév (branche instable de développement) qui peut elle, acceuillir des branches à merge depuis n'importe quelle source